### PR TITLE
Fix: Hide auth buttons for logged-in users

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -343,7 +343,7 @@ button:hover {
 }
 
 .hidden {
-  display: none;
+  display: none !important;
 }
 
 #results-container, #posts-container {


### PR DESCRIPTION
The sign-in and sign-up buttons were not being hidden for authenticated users due to a CSS specificity issue.

The `public/auth.js` script correctly adds the `.hidden` class to the `#signed-out` container when a user is logged in. However, other CSS rules were overriding the `display: none` property of the `.hidden` class.

This change resolves the issue by increasing the specificity of the `.hidden` class by adding `!important`. This ensures that any element with this class is correctly hidden, providing the expected user experience.